### PR TITLE
Fixup Outdated SuiteSparse URL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -74,7 +74,7 @@ It will contain INDDGO, Metis, and SuiteSparse.
 > make
 > OPTIONAL: make install
 > cd ..
-> wget http://www.cise.ufl.edu/research/sparse/SuiteSparse/SuiteSparse-4.0.2.tar.gz
+> wget http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.0.2.tar.gz
 > tar xzvf SuiteSparse-4.0.2.tar.gz
 > cd SuiteSparse
 > make

--- a/thirdparty.txt
+++ b/thirdparty.txt
@@ -14,7 +14,7 @@ SUITESPARSE /*tested with 4.0.0*/
  * you must compile with -DNPARTITION, which can be added to a compile flag 
  * in SuiteSparse_config.mk. For use with INDDGO 'make library' is sufficient. 
  */
-http://www.cise.ufl.edu/research/sparse/ 
+http://faculty.cse.tamu.edu/davis/suitesparse.html
 
 
 /*THESE ARE SUPERCEDED BY SUITESPARSE COMPLETE PACKAGE*/


### PR DESCRIPTION
The old project url, http://www.cise.ufl.edu/research/sparse/, now redirects to http://faculty.cse.tamu.edu/davis/research.html – the SuiteSparse project page seems to be http://faculty.cse.tamu.edu/davis/suitesparse.html, though.

Also update the installation instructions.
