### PR TITLE
Cleanup Whitespace, Comments in make.inc Templates

### DIFF
--- a/make.inc.parallel
+++ b/make.inc.parallel
@@ -1,6 +1,6 @@
 #
 # This file is part of INDDGO.
-# Copyright (C) 2012, Oak Ridge National Laboratory 
+# Copyright (C) 2012, Oak Ridge National Laboratory
 #
 
 #----------------------------------------------------------------
@@ -8,86 +8,93 @@
 # This should be a full path to the root directory for INDDGO.
 # (i.e. the parent of lib_graphd, libtree_d, madness, wis, etc.)
 #
-SRC_DIR = 
+
+SRC_DIR =
 
 #----------------------------------------------------------------
 # REQUIRED USER-SUPPLIED OPTIONS
 # Determine which third-party software is used in the compilation.
 # For any enabled packages, directories need to be set in next section.
-# With default settings, necessary dirs are marked with #FILL IN
+# With default settings, necessary dirs are marked with `#FILL IN`.
 
-#WARNING: If HAS_PARMETIS=1, you must also set HAS_METIS=1 (metis is
-#included in the parmetis install).
+# WARNING: If HAS_PARMETIS=1, you must also set HAS_METIS=1 (metis is
+#          included in the parmetis install).
 
-HAS_ARPACK	= 0
+HAS_ARPACK      = 0
 HAS_SUITESPARSE = 1
-HAS_PARMETIS	= 1
-HAS_METIS	= 1
-HAS_IGRAPH	= 0
-HAS_GMP		= 0
-HAS_GTEST	= 0
-# Set to 1 if you have boost installed on your system
-# Many linux systems have it installed by default
-HAS_BOOST = 0
-#Slepc is needed if you want eigen values
-HAS_PETSC	= 1
-HAS_SLEPC	= 1
-# Set whether serial or parallel version is desired for WIS.
-IS_PARALLEL	= 1
-HAS_MADNESS	= 1
-# madness is included in the INDDGO distribution, and is required to be compiled for successful parallel execution of WIS.
-MAC_OSX	     	= 0
-#some compiler flags cause problems on MacOSX. Set this to 1 if you're having problems compiling on OSX.
+HAS_PARMETIS    = 1
+HAS_METIS       = 1
+HAS_IGRAPH      = 0
+HAS_GMP         = 0
+HAS_GTEST       = 0
 
-#use this to turn logging on/off
-LOG_ENABLED = 0
+# Set to 1 if you have boost installed on your system.
+# Many linux systems have it installed by default.
+HAS_BOOST       = 0
+
+# Slepc is needed if you want eigen values.
+HAS_PETSC       = 1
+HAS_SLEPC       = 1
+
+# Set whether serial or parallel version is desired for WIS.
+IS_PARALLEL     = 1
+HAS_MADNESS     = 1
+
+# Madness is included in the INDDGO distribution, and is required to be compiled for successful parallel execution of WIS.
+
+# Some compiler flags cause problems on Mac OS X. Set this to 1 if you're
+# having problems compiling on OS X.
+MAC_OSX         = 0
+
+#use this to turn logging on/off.
+LOG_ENABLED     = 0
 
 #----------------------------------------------------------------
 #  OPTIONAL USER-SUPPLIED DIRECTORY VARIABLES
 # These are the directories to find optional third-party software.
 #
 
-ARPACK = 
+ARPACK =
 
-#directory containing SuiteSparse installation. This includes AMD and SuiteSparse_config/UFconfig.
-SUITESPARSE = 
+# Directory containing SuiteSparse installation. This includes AMD and SuiteSparse_config/UFconfig.
+SUITESPARSE =
 
-#NOTE: the build directory is usually platform dependent.
-PARMETIS_SRC_DIR = 
-PARMETIS_LIB_DIR =  
+# NOTE: the build directory is usually platform dependent.
+PARMETIS_SRC_DIR =
+PARMETIS_LIB_DIR =
 METIS_SRC_DIR  = $(PARMETIS_SRC_DIR)/metis
 METIS_LIB_DIR = $(PARMETIS_SRC_DIR)/metis/build/Linux-x86_64/libmetis/
 
-IGRAPH = 
+IGRAPH =
 IGRAPH_INSTALL_DIR = $(IGRAPH)/deploy
 
-GMP    = 
+GMP    =
 
-GTEST_INCLUDE_DIR = 
+GTEST_INCLUDE_DIR =
 
-PETSC_DIR = 
-SLEPC_DIR = 
+PETSC_DIR =
+SLEPC_DIR =
 
 #----------------------------------------------------------------
 #
 # Compilers, Flags and System Tools
 #
 
-CC	= gcc
+CC      = gcc
 CXX     = g++
 # Set the following flag to 1 if you are compiling with a gcc version < 4.4
-OLDGCC	= 0
+OLDGCC  = 0
 
 CFLAGS = -O3
 CPPFLAGS =
-LDFLAGS = 
+LDFLAGS =
 
 ifeq ($(HAS_BOOST),1)
 CFLAGS := $(CFLAGS) -DHAS_BOOST
 endif
 
 ifeq ($(LOG_ENABLED), 1)
-CFLAGS := $(CFLAGS) -D__LOG_ENABLE__ 
+CFLAGS := $(CFLAGS) -D__LOG_ENABLE__
 endif
 
 ifeq ($(HAS_MADNESS),1)
@@ -96,7 +103,7 @@ ifeq ($(OLDGCC), 1)
 CFLAGS := $(CFLAGS) -D__MADNESS__ -D_OLDGCC -Wno-strict-aliasing -Wno-deprecated -ffast-math
 endif
 ifeq ($(OLDGCC), 0)
-CPPFLAGS := $(CPPFLAGS) -std=c++0x 
+CPPFLAGS := $(CPPFLAGS) -std=c++0x
 CFLAGS := $(CFLAGS) -D__MADNESS__ -std=c++0x -Wno-strict-aliasing -Wno-deprecated -ffast-math
 endif
 endif
@@ -115,11 +122,11 @@ CXX     = mpicxx
 endif
 
 ifeq ($(HAS_GTEST),1)
-CFLAGS	:= $(CFLAGS) -I$(GTEST_INCLUDE_DIR)
+CFLAGS  := $(CFLAGS) -I$(GTEST_INCLUDE_DIR)
 endif
 
 #FC      = gfortran
-#FFLAGS	= -O3 -m64
+#FFLAGS = -O3 -m64
 
 CD      = cd
 ECHO    = echo
@@ -134,7 +141,7 @@ VALGRIND_FLAGS= -g -O0
 RM      = rm
 RMFLAGS = -f
 SHELL   = /bin/sh
-AR = ar 
+AR = ar
 ARFLAGS = rv
 RANLIB   = ranlib
 
@@ -148,19 +155,19 @@ RANLIB   = ranlib
 ifeq ($(SRC_DIR),)
 $(error User must set SRC_DIR in make.inc)
 endif
-GRAPH  	= $(SRC_DIR)/lib_graphd
-TREE   	= $(SRC_DIR)/lib_treed
-PTREE	= $(SRC_DIR)/lib_ptreed
-WIS 	= $(SRC_DIR)/max_wis
-VIZ	= $(SRC_DIR)/viz
-UTIL	= $(SRC_DIR)/util
+GRAPH   = $(SRC_DIR)/lib_graphd
+TREE    = $(SRC_DIR)/lib_treed
+PTREE   = $(SRC_DIR)/lib_ptreed
+WIS     = $(SRC_DIR)/max_wis
+VIZ     = $(SRC_DIR)/viz
+UTIL    = $(SRC_DIR)/util
 INDDGO_LIB_DIR = $(SRC_DIR)/lib
 INDDGO_LIB = -L$(INDDGO_LIB_DIR)
 INDDGO_BIN = $(SRC_DIR)/bin
 SUBDIRS = $(GRAPH) $(TREE) $(PTREE)  $(VIZ) $(WIS) $(UTIL)
-MADNESS	= $(SRC_DIR)/madness
+MADNESS = $(SRC_DIR)/madness
 MADNESS_INSTALL_DIR = $(MADNESS)/deploy
-UTHASH_INCDIR	= -I$(SRC_DIR)/uthash-1.9.3/src
+UTHASH_INCDIR   = -I$(SRC_DIR)/uthash-1.9.3/src
 
 RUN_TEST=./run_test.sh
 
@@ -170,13 +177,13 @@ RUN_TEST=./run_test.sh
 #
 ifeq ($(HAS_ARPACK),1)
 ifeq ($(ARPACK), )
-$(error When HAS_ARPACK = 1, you must define the ARPACK directory variable)  
+$(error When HAS_ARPACK = 1, you must define the ARPACK directory variable)
 endif
 endif
 
 ifeq ($(HAS_SUITESPARSE),1)
 ifeq ($(SUITESPARSE), )
-$(error When HAS_SUITESPARSE = 1, you must define the SUITESPARSE directory variable)  
+$(error When HAS_SUITESPARSE = 1, you must define the SUITESPARSE directory variable)
 endif
 endif
 
@@ -185,19 +192,19 @@ ifeq ($(HAS_METIS),0)
 $(error When HAS_PARMETIS = 1, HAS_METIS must also be 1)
 endif
 ifeq ($(PARMETIS_LIB_DIR), )
-$(error When HAS_PARMETIS = 1, you must define the PARMETIS_LIB_DIR directory variable)  
+$(error When HAS_PARMETIS = 1, you must define the PARMETIS_LIB_DIR directory variable)
 endif
 ifeq ($(PARMETIS_SRC_DIR), )
-$(error When HAS_PARMETIS = 1, you must define the PARMETIS_SRC_DIR directory variable)  
+$(error When HAS_PARMETIS = 1, you must define the PARMETIS_SRC_DIR directory variable)
 endif
 endif
 
 ifeq ($(HAS_METIS),1)
 ifeq ($(METIS_LIB_DIR), )
-$(error When HAS_METIS = 1, you must define the METIS_LIB_DIR directory variable)  
+$(error When HAS_METIS = 1, you must define the METIS_LIB_DIR directory variable)
 endif
 ifeq ($(METIS_SRC_DIR), )
-$(error When HAS_METIS = 1, you must define the METIS_SRC_DIR directory variable)  
+$(error When HAS_METIS = 1, you must define the METIS_SRC_DIR directory variable)
 endif
 endif
 
@@ -218,19 +225,19 @@ endif
 
 ifeq ($(HAS_IGRAPH),1)
 ifeq ($(IGRAPH), )
-$(error When HAS_IGRAPH = 1, you must define the IGRAPH directory variable)  
+$(error When HAS_IGRAPH = 1, you must define the IGRAPH directory variable)
 endif
 endif
 
 ifeq ($(HAS_GMP),1)
 ifeq ($(GMP), )
-$(error When HAS_GMP = 1, you must define the GMP directory variable)  
+$(error When HAS_GMP = 1, you must define the GMP directory variable)
 endif
 endif
 
 #------------------------------------------------------------------
-# 
-# Setting auxiliary library variables. 
+#
+# Setting auxiliary library variables.
 # If you have non-default third party builds, you may need to edit this.
 #
 
@@ -242,7 +249,7 @@ ifeq ($(HAS_METIS),1)
 METIS_INCLUDES = -I$(METIS_SRC_DIR)/include -I$(METIS_SRC_DIR)/libmetis -I$(METIS_SRC_DIR)/GKlib -I$(METIS_SRC_DIR)/programs
 endif
 
-PARMETIS_INCDIR= 
+PARMETIS_INCDIR=
 
 ifeq ($(HAS_PARMETIS),1)
 PARMETIS_INCDIR= -I$(PARMETIS_SRC_DIR)/include
@@ -251,13 +258,13 @@ endif
 ARPACK_LIB=
 ifeq ($(HAS_ARPACK),1)
 ARPACK_LIB= -larpack_x86_64 -lgfortran
-endif 
+endif
 
 
 #-----------------------------------------------------------------
 #
 # Start:
-# ARPACK Specific options. 
+# ARPACK Specific options.
 #
 
 PLAT = x86_64
@@ -283,10 +290,10 @@ DIRS        = $(BLASdir) $(LAPACKdir) $(UTILdir) $(SRCdir)
 # %---------------------------------------------------%
 #
 ARPACKLIB  = $(ARPACK)/libarpack_$(PLAT).a
-LAPACKLIB = 
-BLASLIB = 
+LAPACKLIB =
+BLASLIB =
 #
-ALIBS =  $(ARPACKLIB) $(LAPACKLIB) $(BLASLIB) 
+ALIBS =  $(ARPACKLIB) $(LAPACKLIB) $(BLASLIB)
 
 #
 # END:
@@ -296,7 +303,7 @@ ALIBS =  $(ARPACKLIB) $(LAPACKLIB) $(BLASLIB)
 
 #----------------------------------------------------------------
 #
-# Third party dependent flags and library settings. 
+# Third party dependent flags and library settings.
 # You should not need to edit these in almost all cases.
 #
 
@@ -307,7 +314,7 @@ ARPACK_LIB := -L $(ARPACK) $(ARPACK_LIB)
 endif
 
 METIS_LIB =
-VALGRIND_FLAGS= 
+VALGRIND_FLAGS=
 ifeq ($(HAS_METIS),1)
 CFLAGS := $(CFLAGS) -DHAS_METIS -D_FILE_OFFSET_BITS=64
 VALGRIND_FLAGS := $(VALGRINDFLAGS) -DHAS_METIS
@@ -315,7 +322,7 @@ METIS_LIB := -L$(METIS_LIB_DIR) -lmetis
 endif
 
 PARMETIS_LIB=
-PARMETISOBJ= 
+PARMETISOBJ=
 ifeq ($(HAS_PARMETIS),1)
 CFLAGS := $(CFLAGS) -DHAS_PARMETIS
 PARMETISOBJ = $(METIS_LIB_DIR)/libmetis.a $(PARMETIS_LIB_DIR)/libparmetis.a
@@ -339,7 +346,7 @@ SSPARSE_LIB=
 ifeq ($(HAS_SUITESPARSE),1)
 AMD    = $(SUITESPARSE)/AMD
 UFCONFIG = $(SUITESPARSE)/SuiteSparse_config
-CFLAGS := $(CFLAGS) -DHAS_SUITESPARSE 
+CFLAGS := $(CFLAGS) -DHAS_SUITESPARSE
 VALGRIND_FLAGS := $(VALGRINDFLAGS) -DHAS_SUITESPARSE
 AMD_INCDIR= -I$(AMD)/Include -I$(UFCONFIG)
 AMD_LIB= -L$(AMD)/Lib -lamd
@@ -347,12 +354,12 @@ SSPARSE_INCDIR= -I$(SUITESPARSE)/CHOLMOD/Include -I$(SUITESPARSE)/COLAMD/Include
 SSPARSE_LIB= -L$(SUITESPARSE)/CHOLMOD/Lib -lcholmod -L$(SUITESPARSE)/COLAMD/Lib -lcolamd $(AMD_LIB)
 endif
 
-MADNESS_INCDIR= 
-MADNESS_LIB= 
+MADNESS_INCDIR=
+MADNESS_LIB=
 ifeq ($(HAS_MADNESS),1)
 MADNESS_INCDIR= -I$(MADNESS_INSTALL_DIR)/include
 MADNESS_LIB= -L$(MADNESS_INSTALL_DIR)/lib $(MADLIBS) -lpthread
-SUBDIRS := $(SUBDIRS) $(MADNESS) 
+SUBDIRS := $(SUBDIRS) $(MADNESS)
 endif
 
 IGRAPH_LIB=

--- a/make.inc.serial
+++ b/make.inc.serial
@@ -1,6 +1,6 @@
 #
 # This file is part of INDDGO.
-# Copyright (C) 2012, Oak Ridge National Laboratory 
+# Copyright (C) 2012, Oak Ridge National Laboratory
 #
 
 #----------------------------------------------------------------
@@ -8,82 +8,88 @@
 # This should be a full path to the root directory for INDDGO.
 # (i.e. the parent of lib_graphd, libtree_d, madness, wis, etc.)
 #
-SRC_DIR = 
+
+SRC_DIR =
 
 #----------------------------------------------------------------
 # REQUIRED USER-SUPPLIED OPTIONS
 # Determine which third-party software is used in the compilation.
 # For any enabled packages, directories need to be set in next section.
-# With default settings, necessary dirs are marked with #FILL IN
+# With default settings, necessary dirs are marked with `#FILL IN`.
 
-#WARNING: If HAS_PARMETIS=1, you must also set HAS_METIS=1 (metis is
-#included in the parmetis install).
+# WARNING: If HAS_PARMETIS=1, you must also set HAS_METIS=1 (metis is
+#          included in the parmetis install).
 
-# Set to 1 if building on CYGWIN
-# This then defines the variable _GK_ERROR_C_ which
-# cures a compile error when building with gcc and g++ 
-# under cygwin 
+# Set to 1 if building on CYGWIN.
+# This then defines the variable _GK_ERROR_C_ which cures a compile error when
+# building with gcc and g++ under cygwin.
 CYGWIN = 0
 
-HAS_ARPACK	= 0
+HAS_ARPACK      = 0
 HAS_SUITESPARSE = 0
-HAS_PARMETIS	= 0
-HAS_METIS	= 0
-HAS_IGRAPH	= 0
-HAS_GMP		= 0
-HAS_GTEST	= 0
-# Set to 1 if you have boost installed on your system
-# Many linux systems have it installed by default
-HAS_BOOST = 0
-# Set whether serial or parallel version is desired for WIS.
-IS_PARALLEL	= 0
-HAS_MADNESS	= 0
-# madness is included in the INDDGO distribution, but can be set to 0 for serial compilation.
+HAS_PARMETIS    = 0
+HAS_METIS       = 0
+HAS_IGRAPH      = 0
+HAS_GMP         = 0
+HAS_GTEST       = 0
 
-#use this to turn logging on/off
-LOG_ENABLED = 0
+# Set to 1 if you have boost installed on your system.
+# Many linux systems have it installed by default.
+HAS_BOOST       = 0
+
+# Set whether serial or parallel version is desired for WIS.
+IS_PARALLEL     = 0
+
+# MADNESS is included in the INDDGO distribution, but can be set to 0 for
+# serial compilation.
+HAS_MADNESS     = 0
+
+# Use this to turn logging on/off.
+LOG_ENABLED     = 0
 
 #----------------------------------------------------------------
 #  OPTIONAL USER-SUPPLIED DIRECTORY VARIABLES
 # These are the directories to find optional third-party software.
 #
 
-ARPACK = 
+ARPACK =
 
 # Directory containing SuiteSparse source code - not the directory where it
-# is installed 
+# is installed.
 SUITESPARSE = #FILL IN
 
-#NOTE: the build directory is usually platform dependent.
+# NOTE: the build directory is usually platform dependent.
 PARMETIS_SRC_DIR =
-PARMETIS_LIB_DIR =  
-#NOTE: the METIS_SRC_DIR should be the directory containing programs/ and GKLib/ dirs
-#NOTE: when building Metis, we have seen cases where setting IDXTYPEWIDTH=64 in
-#metis.h on a 64-bit system fails, so we recommend leaving IDXTYPEWIDTH=32
-METIS_SRC_DIR  = #FILL IN
+PARMETIS_LIB_DIR =
+
+# NOTE: The METIS_SRC_DIR should be the directory containing the programs/ and
+#       GKLib/ directories.
+# NOTE: When building Metis, we have seen cases where setting IDXTYPEWIDTH=64
+#       in metis.h on a 64-bit system fails, so we recommend leaving
+#       IDXTYPEWIDTH=32.
+METIS_SRC_DIR = #FILL IN
 METIS_LIB_DIR = #FILL IN
 
-
-IGRAPH = 
+IGRAPH =
 IGRAPH_INSTALL_DIR = $(IGRAPH)/deploy
 
-GMP    = 
+GMP    =
 
-GTEST_INCLUDE_DIR = 
+GTEST_INCLUDE_DIR =
 
 #----------------------------------------------------------------
 #
 # Compilers, Flags and System Tools
 #
 
-CC	= gcc
+CC      = gcc
 CXX     = g++
 # Set the following flag to 1 if you are compiling with a gcc version < 4.4
-OLDGCC	= 0
+OLDGCC  = 0
 
 CFLAGS = -O3
-CPPFLAGS = 
-LDFLAGS = 
+CPPFLAGS =
+LDFLAGS =
 
 ifeq ($(CYGWIN), 1)
 CFLAGS:= $(CFLAGS) -D_GK_ERROR_C_
@@ -91,7 +97,7 @@ CPPFLAGS:= $(CPPFLAGS) -D_GK_ERROR_C_
 endif
 
 ifeq ($(LOG_ENABLED), 1)
-CFLAGS := $(CFLAGS) -D__LOG_ENABLE__ 
+CFLAGS := $(CFLAGS) -D__LOG_ENABLE__
 endif
 
 ifeq ($(HAS_BOOST),1)
@@ -101,10 +107,10 @@ endif
 ifeq ($(HAS_MADNESS),1)
 CXX     = mpicxx
 ifeq ($(OLDGCC), 1)
-CFLAGS := $(CFLAGS) -D__MADNESS__ -D_OLDGCC -Wno-strict-aliasing -Wno-deprecated -ffast-math 
+CFLAGS := $(CFLAGS) -D__MADNESS__ -D_OLDGCC -Wno-strict-aliasing -Wno-deprecated -ffast-math
 endif
 ifeq ($(OLDGCC), 0)
-CPPFLAGS := $(CPPFLAGS) -std=c++0x 
+CPPFLAGS := $(CPPFLAGS) -std=c++0x
 CFLAGS := $(CFLAGS) -D__MADNESS__ -std=c++0x -Wno-strict-aliasing -Wno-deprecated -ffast-math -march=native
 endif
 endif
@@ -119,11 +125,11 @@ CXX     = mpicxx
 endif
 
 ifeq ($(HAS_GTEST),1)
-CFLAGS	:= $(CFLAGS) -I$(GTEST_INCLUDE_DIR)
+CFLAGS  := $(CFLAGS) -I$(GTEST_INCLUDE_DIR)
 endif
 
 #FC      = gfortran
-#FFLAGS	= -O3 -m64
+#FFLAGS = -O3 -m64
 
 CD      = cd
 ECHO    = echo
@@ -138,7 +144,7 @@ VALGRIND_FLAGS= -g -O0
 RM      = rm
 RMFLAGS = -f
 SHELL   = /bin/sh
-AR = ar 
+AR = ar
 ARFLAGS = rv
 RANLIB   = ranlib
 
@@ -152,19 +158,19 @@ RANLIB   = ranlib
 ifeq ($(SRC_DIR),)
 $(error User must set SRC_DIR in make.inc)
 endif
-GRAPH  	= $(SRC_DIR)/lib_graphd
-TREE   	= $(SRC_DIR)/lib_treed
-PTREE	= $(SRC_DIR)/lib_ptreed
-WIS 	= $(SRC_DIR)/max_wis
-VIZ	= $(SRC_DIR)/viz
-UTIL	= $(SRC_DIR)/util
+GRAPH   = $(SRC_DIR)/lib_graphd
+TREE    = $(SRC_DIR)/lib_treed
+PTREE   = $(SRC_DIR)/lib_ptreed
+WIS     = $(SRC_DIR)/max_wis
+VIZ     = $(SRC_DIR)/viz
+UTIL    = $(SRC_DIR)/util
 INDDGO_LIB_DIR = $(SRC_DIR)/lib
 INDDGO_LIB = -L$(INDDGO_LIB_DIR)
 INDDGO_BIN = $(SRC_DIR)/bin
 SUBDIRS = $(GRAPH) $(TREE) $(PTREE)  $(VIZ) $(WIS) $(UTIL)
-MADNESS	= $(SRC_DIR)/madness
+MADNESS = $(SRC_DIR)/madness
 MADNESS_INSTALL_DIR = $(MADNESS)/deploy
-UTHASH_INCDIR	= -I$(SRC_DIR)/uthash-1.9.3/src
+UTHASH_INCDIR   = -I$(SRC_DIR)/uthash-1.9.3/src
 
 RUN_TEST=./run_test.sh
 
@@ -174,14 +180,14 @@ RUN_TEST=./run_test.sh
 #
 ifeq ($(HAS_ARPACK),1)
 ifeq ($(ARPACK), )
-$(error When HAS_ARPACK = 1, you must define the ARPACK directory variable)  
+$(error When HAS_ARPACK = 1, you must define the ARPACK directory variable)
 endif
 endif
 
 
 ifeq ($(HAS_SUITESPARSE),1)
 ifeq ($(SUITESPARSE), )
-$(error When HAS_SUITESPARSE = 1, you must define the SUITESPARSE directory variable)  
+$(error When HAS_SUITESPARSE = 1, you must define the SUITESPARSE directory variable)
 endif
 endif
 
@@ -191,37 +197,37 @@ ifeq ($(HAS_METIS),0)
 $(error When HAS_PARMETIS = 1, HAS_METIS must also be 1)
 endif
 ifeq ($(PARMETIS_LIB_DIR), )
-$(error When HAS_PARMETIS = 1, you must define the PARMETIS_LIB_DIR directory variable)  
+$(error When HAS_PARMETIS = 1, you must define the PARMETIS_LIB_DIR directory variable)
 endif
 ifeq ($(PARMETIS_SRC_DIR), )
-$(error When HAS_PARMETIS = 1, you must define the PARMETIS_SRC_DIR directory variable)  
+$(error When HAS_PARMETIS = 1, you must define the PARMETIS_SRC_DIR directory variable)
 endif
 endif
 
 ifeq ($(HAS_METIS),1)
 ifeq ($(METIS_LIB_DIR), )
-$(error When HAS_METIS = 1, you must define the METIS_LIB_DIR directory variable)  
+$(error When HAS_METIS = 1, you must define the METIS_LIB_DIR directory variable)
 endif
 ifeq ($(METIS_SRC_DIR), )
-$(error When HAS_METIS = 1, you must define the METIS_SRC_DIR directory variable)  
+$(error When HAS_METIS = 1, you must define the METIS_SRC_DIR directory variable)
 endif
 endif
 
 ifeq ($(HAS_IGRAPH),1)
 ifeq ($(IGRAPH), )
-$(error When HAS_IGRAPH = 1, you must define the IGRAPH directory variable)  
+$(error When HAS_IGRAPH = 1, you must define the IGRAPH directory variable)
 endif
 endif
 
 ifeq ($(HAS_GMP),1)
 ifeq ($(GMP), )
-$(error When HAS_GMP = 1, you must define the GMP directory variable)  
+$(error When HAS_GMP = 1, you must define the GMP directory variable)
 endif
 endif
 
 #------------------------------------------------------------------
-# 
-# Setting auxiliary library variables. 
+#
+# Setting auxiliary library variables.
 # If you have non-default third party builds, you may need to edit this.
 #
 
@@ -233,7 +239,7 @@ ifeq ($(HAS_METIS),1)
 METIS_INCLUDES = -I$(METIS_SRC_DIR)/include -I$(METIS_SRC_DIR)/libmetis -I$(METIS_SRC_DIR)/GKlib -I$(METIS_SRC_DIR)/programs
 endif
 
-PARMETIS_INCDIR= 
+PARMETIS_INCDIR=
 
 ifeq ($(HAS_PARMETIS),1)
 PARMETIS_INCDIR= -I$(PARMETIS_SRC_DIR)/include
@@ -242,13 +248,13 @@ endif
 ARPACK_LIB=
 ifeq ($(HAS_ARPACK),1)
 ARPACK_LIB= -larpack_x86_64 -lgfortran
-endif 
+endif
 
 
 #-----------------------------------------------------------------
 #
 # Start:
-# ARPACK Specific options. 
+# ARPACK Specific options.
 #
 
 PLAT = x86_64
@@ -274,10 +280,10 @@ DIRS        = $(BLASdir) $(LAPACKdir) $(UTILdir) $(SRCdir)
 # %---------------------------------------------------%
 #
 ARPACKLIB  = $(ARPACK)/libarpack_$(PLAT).a
-LAPACKLIB = 
-BLASLIB = 
+LAPACKLIB =
+BLASLIB =
 #
-ALIBS =  $(ARPACKLIB) $(LAPACKLIB) $(BLASLIB) 
+ALIBS =  $(ARPACKLIB) $(LAPACKLIB) $(BLASLIB)
 
 #
 # END:
@@ -287,7 +293,7 @@ ALIBS =  $(ARPACKLIB) $(LAPACKLIB) $(BLASLIB)
 
 #----------------------------------------------------------------
 #
-# Third party dependent flags and library settings. 
+# Third party dependent flags and library settings.
 # You should not need to edit these in almost all cases.
 #
 
@@ -298,7 +304,7 @@ ARPACK_LIB := -L $(ARPACK) $(ARPACK_LIB)
 endif
 
 METIS_LIB =
-VALGRIND_FLAGS= 
+VALGRIND_FLAGS=
 ifeq ($(HAS_METIS),1)
 CFLAGS := $(CFLAGS) -DHAS_METIS -D_FILE_OFFSET_BITS=64
 VALGRIND_FLAGS := $(VALGRINDFLAGS) -DHAS_METIS
@@ -306,7 +312,7 @@ METIS_LIB := -L$(METIS_LIB_DIR) -lmetis
 endif
 
 PARMETIS_LIB=
-PARMETISOBJ= 
+PARMETISOBJ=
 ifeq ($(HAS_PARMETIS),1)
 CFLAGS := $(CFLAGS) -DHAS_PARMETIS
 PARMETISOBJ = $(METIS_LIB_DIR)/libmetis.a $(PARMETIS_LIB_DIR)/libparmetis.a
@@ -330,8 +336,8 @@ SSPARSE_LIB=
 ifeq ($(HAS_SUITESPARSE),1)
 AMD    = $(SUITESPARSE)/AMD
 UFCONFIG = $(SUITESPARSE)/SuiteSparse_config
-CFLAGS := $(CFLAGS) -DHAS_SUITESPARSE 
-VALGRIND_FLAGS := $(VALGRINDFLAGS) -DHAS_SUITESPARSE 
+CFLAGS := $(CFLAGS) -DHAS_SUITESPARSE
+VALGRIND_FLAGS := $(VALGRINDFLAGS) -DHAS_SUITESPARSE
 AMD_INCDIR= -I$(AMD)/Include -I$(UFCONFIG)
 AMD_LIB= -L$(AMD)/Lib -lamd
 SSPARSE_INCDIR= -I$(SUITESPARSE)/CHOLMOD/Include -I$(SUITESPARSE)/COLAMD/Include $(AMD_INCDIR)
@@ -339,12 +345,12 @@ SSPARSE_LIB= -L$(SUITESPARSE)/CHOLMOD/Lib -lcholmod -L$(SUITESPARSE)/COLAMD/Lib 
 endif
 
 
-MADNESS_INCDIR= 
-MADNESS_LIB= 
+MADNESS_INCDIR=
+MADNESS_LIB=
 ifeq ($(HAS_MADNESS),1)
 MADNESS_INCDIR= -I$(MADNESS_INSTALL_DIR)/include
 MADNESS_LIB= -L$(MADNESS_INSTALL_DIR)/lib $(MADLIBS) -lpthread
-SUBDIRS := $(SUBDIRS) $(MADNESS) 
+SUBDIRS := $(SUBDIRS) $(MADNESS)
 endif
 
 IGRAPH_LIB=


### PR DESCRIPTION
- Strip all trailing spaces
- Convert tabs to spaces where used for alignment
- Cleanup comments in the upper parts of both files
